### PR TITLE
cmd/capture.md: Remove context field from capture result object

### DIFF
--- a/src/cmd/capture.md
+++ b/src/cmd/capture.md
@@ -36,6 +36,6 @@ let result = ${
 }
 
 std.assert(std.type(result) == "error")
-std.assert(result.context.stdout == "Hello world!\n")
-std.assert(result.context.stderr == "The next command wil fail\n")
+std.assert(result.stdout == "Hello world!\n")
+std.assert(result.stderr == "The next command wil fail\n")
 ```


### PR DESCRIPTION
I believe this `context` field should be removed? It didn't work locally ("Panic in my-script.hsh (line 17, column 40): index ("context") out of bounds") so I tried without and that worked. On the latest tag (0.1.4).